### PR TITLE
Unable to decode json with invalid utf8 character

### DIFF
--- a/core/class/script.class.php
+++ b/core/class/script.class.php
@@ -301,7 +301,7 @@ class scriptCmd extends cmd {
 					script::$_requet_cache[$this->getConfiguration('urlJson')] = $json_str;
 				}
 			}
-			$json = json_decode($json_str, true);
+			$json = json_decode($json_str, true, 512, JSON_INVALID_UTF8_IGNORE);
 			if ($json === null) {
 				throw new Exception(__('Json invalide ou non décodable : ', __FILE__) . $json_str);
 			}


### PR DESCRIPTION
Change flags parameter of json_decode to ignore invalid utf8
JSON_INVALID_UTF8_IGNORE was added in php 7.2
There is also  JSON_INVALID_UTF8_SUBSTITUTE

See also: https://community.jeedom.com/t/unexpected-end-of-json-input/71449/29?u=jpty