### PR TITLE
Version mini 4.2

### DIFF
--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -15,7 +15,7 @@
     "name": "Script",
     "licence": "AGPL",
     "author": "Jeedom SAS",
-    "require": "3.2",
+    "require": "4.2",
     "category": "programming",
     "changelog": "https:\/\/doc.jeedom.com\/#language#\/plugins\/programming\/script\/changelog",
     "documentation": "https:\/\/doc.jeedom.com\/#language#\/plugins\/programming\/script\/",


### PR DESCRIPTION
Vu que la fonction `[displayException](ajax::error(displayException($e), $e->getCode());)` n'est prise en compte uniquement a partir de la version 4.2. 