### PR TITLE
patch refresh functions

### DIFF
--- a/core/class/script.class.php
+++ b/core/class/script.class.php
@@ -30,14 +30,15 @@ class script extends eqLogic {
 
 	public static function cron() {
 		$dateRun = new DateTime();
-		foreach (eqLogic::byType('script') as $eqLogic) {
+		/** @var script */
+		foreach (eqLogic::byType('script', true) as $eqLogic) {
 			$autorefresh = $eqLogic->getConfiguration('autorefresh');
-			if ($eqLogic->getIsEnable() == 1 && $autorefresh != '') {
+			if ($autorefresh != '') {
 				try {
 					$c = new Cron\CronExpression(checkAndFixCron($autorefresh), new Cron\FieldFactory);
 					if ($c->isDue($dateRun)) {
 						try {
-							$eqLogic->refresh();
+							$eqLogic->refreshAllInfo();
 						} catch (Exception $exc) {
 							log::add('script', 'error', __('Erreur pour ', __FILE__) . $eqLogic->getHumanName() . ' : ' . $exc->getMessage());
 						}
@@ -58,17 +59,18 @@ class script extends eqLogic {
 			$refresh->setLogicalId('refresh');
 			$refresh->setIsVisible(1);
 			$refresh->setName(__('Rafraichir', __FILE__));
+			$refresh->setType('action');
+			$refresh->setSubType('other');
+			$refresh->setEqLogic_id($this->getId());
+			$refresh->save();
 		}
-		$refresh->setType('action');
-		$refresh->setSubType('other');
-		$refresh->setEqLogic_id($this->getId());
-		$refresh->save();
 	}
 
-	public function refresh() {
+	public function refreshAllInfo() {
+		/** @var scriptCmd */
 		foreach ($this->getCmd('info') as $cmd) {
 			try {
-				$cmd->refresh();
+				$cmd->refreshInfo();
 			} catch (Exception $exc) {
 				log::add('script', 'error', __('Erreur pour ', __FILE__) . $cmd->getHumanName() . ' : ' . $exc->getMessage());
 			}
@@ -92,7 +94,7 @@ class scriptCmd extends cmd {
 		return false;
 	}
 
-	public function refresh() {
+	public function refreshInfo() {
 		if ($this->getType() != 'info' || trim($this->getConfiguration('request')) == '') {
 			return;
 		}
@@ -118,7 +120,7 @@ class scriptCmd extends cmd {
 		if ($this->getLogicalId() == 'refresh' || $this->getEqlogic()->getIsEnable() != 1) {
 			return;
 		}
-		$this->refresh();
+		$this->refreshInfo();
 	}
 
 	private function replaceTags($request) {
@@ -133,7 +135,7 @@ class scriptCmd extends cmd {
 
 	public function execute($_options = null) {
 		if ($this->getLogicalId() == 'refresh') {
-			$this->getEqLogic()->refresh();
+			$this->getEqLogic()->refreshAllInfo();
 			return;
 		}
 		$result = false;
@@ -389,7 +391,7 @@ class scriptCmd extends cmd {
 			if ($this->getEqLogic()->getConfiguration('delayBeforeRefrehInfo') != '') {
 				usleep($this->getEqLogic()->getConfiguration('delayBeforeRefrehInfo') * 1000000);
 			}
-			$this->getEqLogic()->refresh();
+			$this->getEqLogic()->refreshAllInfo();
 		}
 	}
 

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -4,6 +4,10 @@
 >
 >Pour rappel s'il n'y a pas d'information sur la mise à jour, c'est que celle-ci concerne uniquement de la mise à jour de documentation, de traduction ou de texte
 
+# 06/05/2024
+
+- Changement interne pour éviter des effets de bord non désirés. La fonction "refresh" de la class *script* a été renommée "refreshAllInfo" et celle de le class *scriptCmd* a été renommée "refreshInfo". Si vous utilisiez ces méthodes dans vos scénarios bloc code vous devez les corriger.
+
 # 11/01/2024
 
 - Correction d'un bug sur la mise à jour des commandes info lors d'une action


### PR DESCRIPTION
## Description
refresh function in eqLogic & cmd class override parent refresh functions but it shouldn't
This leads to strange behavior


### Suggested changelog entry

*changelog déjà mis à jour*

Changement interne pour éviter des effets de bord non désirés. La fonction "refresh" de la class *script* a été renommée "refreshAllInfo" et celle de le class *scriptCmd* a été renommée "refreshInfo". Si vous utilisiez ces méthodes dans vos scénarios bloc code vous devez les corriger.

### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [[La ligne directrice pour contribuer à ce projet / Contribution guidelines for this project](.github/CONTRIBUTING.md)).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
